### PR TITLE
Added Ignorance for Assemblies and Assets in External Folder

### DIFF
--- a/ModTool.Editor.Exporting/ExportStep.cs
+++ b/ModTool.Editor.Exporting/ExportStep.cs
@@ -311,7 +311,7 @@ namespace ModTool.Editor.Exporting
             {
                 string path = AssetDatabase.GUIDToAssetPath(guid);
 
-                if (path.Contains("/ModTool/") || path.Contains("/Editor/"))
+                if (path.Contains("/ModTool/") || path.Contains("/Editor/") || path.Contains("/External/"))
                     continue;
 
                 if (path.StartsWith("Packages"))

--- a/ModTool.Editor.Exporting/ExportStep.cs
+++ b/ModTool.Editor.Exporting/ExportStep.cs
@@ -12,7 +12,6 @@ using ModTool.Shared.Verification;
 
 using Mono.Cecil;
 using Mono.Cecil.Cil;
-using System.Text.RegularExpressions;
 
 namespace ModTool.Editor.Exporting
 {
@@ -331,6 +330,7 @@ namespace ModTool.Editor.Exporting
             return assets;
         }
 
+        //generate a hashset of assembly names that are from other mods
         private HashSet<string> FindIgnoredAssemblies()
         {
             List<Asset> assets = new List<Asset>();


### PR DESCRIPTION
Made a few changes to ExportStep.cs GetContent class
Modified the GetAssets function to ignore paths containing "/External/"
Also modified GetAssemblies function to generate a list of assembly names to ignore. Set it up so the filter checks for ignored assemblies for both assetsDirectory and assemblyDirectory, but IsModAssembly is only used to check the assemblyDirectory, like before.